### PR TITLE
Use uint16_t as fp16 storage type on windows

### DIFF
--- a/.github/workflows/windows_fp16.yml
+++ b/.github/workflows/windows_fp16.yml
@@ -1,0 +1,34 @@
+name: "Build Test - Windows Meson (FP16)"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-2022, windows-2025 ]
+
+    name: Windows Meson build & test 
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: -${{ github.event.pull_request.commits }}
+      - name: Install submodules
+        run: git submodule sync && git submodule update --init --recursive
+      - name: Install Python Dependencies
+        run: pip install meson==1.7.2 ninja
+      - name: Prepare MSVC
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          architecture: x64
+      - name: Prepare Build
+        run: meson setup --native-file windows-native.ini builddir
+      - name: Run Build
+        run: meson compile -C builddir
+      - name: Run Test Suite
+        run: meson test -C builddir

--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -26,7 +26,11 @@
 #ifdef USE__FP16
 #define _FP16 __fp16
 #else
+#if defined(_WIN32)
+#define _FP16 uint16_t
+#else
 #define _FP16 _Float16
+#endif
 #endif
 #endif
 

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -339,6 +339,20 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
                  unsigned int size_res);
 
 /**
+ * @brief rmsnorm each row of the tensor
+ * @param[in] input _FP16 * for input
+ * @param[in] gamma _FP16 * for gamma multiplier for each row
+ * @param[in] result _FP16 * for result
+ * @param[in] epsilon epsilon to add to each row sum to prevent division by zero
+ * @param[in] height height of the tensor
+ * @param[in] width width of the tensor
+ * @param[in] use_svm whether to treat pointers as SVM
+ */
+void rmsnorm_cl(const _FP16 *input, const _FP16 *gamma, _FP16 *result,
+                const _FP16 epsilon, unsigned int height, unsigned int width,
+                const bool use_svm = true);
+
+/**
  * @brief     fp16 sscal value element by element immediately
  * @param[in] X _FP16 * input
  * @param[in] N unsigned int number of elements

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -100,6 +100,22 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
                               size_res);
 }
 
+void rmsnorm_cl(const _FP16 *input, const _FP16 *gamma, _FP16 *result,
+                const _FP16 epsilon, unsigned int height, unsigned int width,
+                bool use_svm) {
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+
+  ClContext::SharedPtrClKernel kernel_rmsnorm_fp16_ptr =
+    blas_cc->registerClKernel(rmsnorm_fp16_kernel, "rmsnorm_cl_fp16");
+  if (!kernel_rmsnorm_fp16_ptr) {
+    return;
+  }
+
+  rmsnorm_cl_internal<_FP16>(kernel_rmsnorm_fp16_ptr, input, gamma, result,
+                             epsilon, height, width, use_svm);
+}
+
 void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));

--- a/nntrainer/tensor/cl_operations/blas_kernels_templates.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels_templates.h
@@ -367,7 +367,7 @@ inline static void rmsnorm_cl_internal(ClContext::SharedPtrClKernel kernel,
     }
   }
 
-  if (!kernel->SetKernelArguments(3, &epsilon, sizeof(float))) {
+  if (!kernel->SetKernelArguments(3, &epsilon, sizeof(T))) {
     return;
   }
   if (!kernel->SetKernelArguments(4, &height, sizeof(int))) {

--- a/nntrainer/tensor/cl_operations/cl_kernels/rmsnorm_fp16.cl
+++ b/nntrainer/tensor/cl_operations/cl_kernels/rmsnorm_fp16.cl
@@ -1,31 +1,49 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#ifdef cl_intel_required_subgroup_size
+#pragma OPENCL EXTENSION cl_intel_subgroups : enable
+#pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
+#define INTEL_GPU 1
+#define REQD_SUBGROUP_SIZE_32 __attribute__((intel_reqd_sub_group_size(32)))
+#elif defined(cl_qcom_reqd_sub_group_size)
+#pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+#define ADRENO_GPU 1
+#define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+#endif
+
+#ifdef INTEL_GPU
+REQD_SUBGROUP_SIZE_32
+#elif defined(ADRENO_GPU)
+REQD_SUBGROUP_SIZE_64
+#endif
+
 __kernel void
 rmsnorm_cl_fp16(__global const half *input, // Input tensor
                 __global half *output,      // Output tensor
                 __global const half *alpha, // Alpha values (one for each width)
                 half epsilon,
-                int B, // Number of batches
-                int C, // Number of channels
                 int H, // Height of feature map
                 int W  // Width of feature map
 ) {
-  int global_id = get_global_id(0); // Get the global work item index
-
   // Compute the corresponding batch, height, and channel indices
-  int n = global_id / C;    // Batch index
-  int c = global_id % C;    // Height index
-  int h = get_global_id(1); // Channel index
-  int index = ((n * C + c) * H + h) * W;
-
+  int h = get_group_id(0);
+  int index = h * W;
   // Calculate RMS norm for the current channel, height, and batch
-  half sum_squares = 0.0f;
-  for (int j = 0; j < W; ++j) {
-    sum_squares += input[index + j] * input[index + j];
+  __global const half4 *in = (__global const half4 *)(input + index);
+  half4 sum_squares_4 = 0.0h;
+  for (int i = get_local_id(0); i < W / 4; i += get_local_size(0)) {
+    sum_squares_4 += in[i] * in[i];
   }
-  sum_squares /= W;
-  half rms_norm = sqrt((float)(sum_squares + epsilon));
-  // Each work item processes all width elements for its specific n, h, c
-  for (int w = 0; w < W; ++w) {
-    output[index + w] = (input[index + w] / rms_norm) * alpha[w];
+
+  half sum_squares =
+    sum_squares_4.x + sum_squares_4.y + sum_squares_4.z + sum_squares_4.w;
+  sum_squares = sub_group_reduce_add(sum_squares);
+
+  const half mean = sum_squares / W;
+  const half scale = 1.0h / half_sqrt(mean + epsilon);
+
+  __global half4 *out = (__global half4 *)(output + index);
+  __global const half4 *a = (__global const half4 *)(alpha);
+  for (int i = get_local_id(0); i < W / 4; i += get_local_size(0)) {
+    out[i] = in[i] * scale * a[i];
   }
 }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
@@ -257,8 +257,7 @@ static void __ggml_quantize_mat_q8_0_4x8(const _FP16 *__restrict x,
 }
 
 template <>
-void __ggml_dequantize_row_q8_K(const void *__restrict _x, _FP16 *__restrict y,
-                                int64_t k) {
+void __ggml_dequantize_row_q8_K(const void *_x, _FP16 *y, int64_t k) {
   assert(k % QK_K == 0);
   const int64_t nb = k / QK_K;
   const block_q8_K *__restrict x = (const block_q8_K *__restrict)_x;
@@ -313,9 +312,7 @@ void __ggml_quantize_row_q8_K_ref(const _FP16 *__restrict x,
   }
 }
 
-template <>
-void __ggml_quantize_row_q8_K(const _FP16 *__restrict x, void *__restrict y,
-                              int64_t k) {
+template <> void __ggml_quantize_row_q8_K(const _FP16 *x, void *y, int64_t k) {
   __ggml_quantize_row_q8_K_ref(x, y, k);
 }
 

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -20,6 +20,8 @@
 #include <limits>
 #include <stddef.h>
 
+#include <tensor_dim.h>
+
 namespace nntrainer::avx2 {
 
 #ifdef ENABLE_FP16
@@ -31,7 +33,7 @@ namespace nntrainer::avx2 {
  * @param[in]  input vector containing 16-bit floating point values
  * @param[out] output vector containing single-precision floating point values.
  */
-void vcvt_f16_f32(unsigned int N, const _Float16 *input, float *output);
+void vcvt_f16_f32(unsigned int N, const _FP16 *input, float *output);
 
 /**
  * @brief  Converts single-precision floating point values to half-precision
@@ -41,7 +43,7 @@ void vcvt_f16_f32(unsigned int N, const _Float16 *input, float *output);
  * @param[in]  input vector containing single-precision floating point values
  * @param[out] output vector containing 16-bit floating point values
  */
-void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output);
+void vcvt_f32_f16(unsigned int N, const float *input, _FP16 *output);
 
 /**
  * @brief     check if the X has NaN value
@@ -50,7 +52,7 @@ void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output);
  * @param[in] X half-precision * for Vector X
  * @param[out] false if it has NaN or inf
  */
-bool is_valid(const unsigned int N, const _Float16 *X);
+bool is_valid(const unsigned int N, const _FP16 *X);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -21,13 +21,13 @@
 
 namespace nntrainer::avx2 {
 
-void vcvt_f16_f32(unsigned int N, const _Float16 *input, float *output) {
+void vcvt_f16_f32(unsigned int N, const _FP16 *input, float *output) {
   assert(N != 0);
   assert(input != NULL);
   assert(output != NULL);
 
   unsigned int idx = 0;
-  const _Float16 *data = (const _Float16 *)input;
+  const _FP16 *data = (const _FP16 *)input;
 
   // 16 half-precision floating point values to single-precision values
   for (; N - idx >= 16; idx += 16) {
@@ -57,13 +57,13 @@ void vcvt_f16_f32(unsigned int N, const _Float16 *input, float *output) {
   }
 }
 
-void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output) {
+void vcvt_f32_f16(unsigned int N, const float *input, _FP16 *output) {
   assert(N != 0);
   assert(input != NULL);
   assert(output != NULL);
 
   unsigned int idx = 0;
-  _Float16 *out_data = (_Float16 *)output;
+  _FP16 *out_data = (_FP16 *)output;
 
   // 16 single-precision floating point values to half-precision values
   for (; N - idx >= 16; idx += 16) {
@@ -97,14 +97,14 @@ void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output) {
   }
   // remaining single-precision floating point values to half-precision values
   while (idx < N) {
-    *out_data = static_cast<_Float16>(*input);
+    *out_data = static_cast<_FP16>(*input);
     ++out_data;
     ++input;
     ++idx;
   }
 }
 
-bool is_valid(const unsigned int N, const _Float16 *input) {
+bool is_valid(const unsigned int N, const _FP16 *input) {
   assert(N != 0);
   assert(input != NULL);
 

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -11,6 +11,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <numeric>
 
 #include <cpu_backend.h>
 #include <half_tensor.h>

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -1756,22 +1756,38 @@ TEST(blas_kernels, absolute_sum) {
   EXPECT_FLOAT_EQ(cpu_result, gpu_result);
 }
 
-TEST(blas_kernels, rmsnorm_fp32) {
+#if defined(_WIN32)
+#define NNTR_COMPUTE_FP16_TO_FP32(x) compute_fp16_to_fp32(x)
+#define NNTR_COMPUTE_FP32_TO_FP16(x) compute_fp32_to_fp16(x)
+#else
+#define NNTR_COMPUTE_FP16_TO_FP32(x) x
+#define NNTR_COMPUTE_FP32_TO_FP16(x) x
+#endif
+
+template <typename T>
+static void rmsnorm_67_3072(const nntrainer::TensorDim::DataType data_type) {
   const int batch = 1;
   const int channel = 1;
   const int height = 67;
   const int width = 3072;
 
-  const float alpha = 1e-1;
+  const float alpha = 1e-1f;
   const int MOD = 10;
 
+  nntrainer::TensorDim::TensorType t_type_nchw = {nntrainer::Tformat::NCHW,
+                                                  data_type};
+
+  nntrainer::Tensor in(batch, channel, height, width, t_type_nchw);
+  nntrainer::Tensor gamma(1, 1, 1, width, t_type_nchw);
+  nntrainer::Tensor out_cl(batch, channel, height, width, t_type_nchw);
+
+  // Use FP32 CPU as reference implementation (FP16 CPU does not exist on
+  // Windows platform)
   nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
     nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
 
   nntrainer::Tensor in_fp32(batch, channel, height, width, t_type_nchw_fp32);
   nntrainer::Tensor gamma_fp32(1, 1, 1, width, t_type_nchw_fp32);
-  nntrainer::Tensor out_cl_fp32(batch, channel, height, width,
-                                t_type_nchw_fp32);
   nntrainer::Tensor out_ref_fp32(batch, channel, height, width,
                                  t_type_nchw_fp32);
 
@@ -1780,41 +1796,52 @@ TEST(blas_kernels, rmsnorm_fp32) {
                             j * (batch * height) + k * (width) + l + 1) %
                            MOD) *
                             alpha);
+
+  for (int b = 0; b < batch; ++b) {
+    for (int c = 0; c < channel; ++c) {
+      for (int h = 0; h < height; ++h) {
+        for (int w = 0; w < width; ++w) {
+          in.setValue(b, c, h, w,
+                      NNTR_COMPUTE_FP32_TO_FP16(in_fp32.getValue(b, c, h, w)));
+        }
+      }
+    }
+  }
+
   for (int l = 0; l < width; ++l) {
     float val = ((l + 1) % MOD) * alpha;
     gamma_fp32.setValue(0, 0, 0, l, val);
+    gamma.setValue(0, 0, 0, l, NNTR_COMPUTE_FP32_TO_FP16(val));
   }
 
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
 
   /// Initialize GPU input/ouput data
-  void *in_fp32_svm = allocateSVM(in_fp32.size() * sizeof(float));
-  void *gamma_fp32_svm = allocateSVM(gamma_fp32.size() * sizeof(float));
-  void *out_fp32_svm = allocateSVM(out_cl_fp32.size() * sizeof(float));
+  void *in_svm = allocateSVM(in.size() * sizeof(T));
+  void *gamma_svm = allocateSVM(gamma.size() * sizeof(T));
+  void *out_svm = allocateSVM(out_cl.size() * sizeof(T));
+  float *out_svm_fp32 = new float[out_cl.size()];
 
-  blas_cc->command_queue_inst_.enqueueSVMMap(
-    in_fp32_svm, in_fp32.size() * sizeof(float), false);
-  blas_cc->command_queue_inst_.enqueueSVMMap(
-    gamma_fp32_svm, gamma_fp32.size() * sizeof(float), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(in_svm, in.size() * sizeof(T),
+                                             false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(gamma_svm,
+                                             gamma.size() * sizeof(T), false);
 
-  std::memcpy(in_fp32_svm, in_fp32.getData<float>(),
-              in_fp32.size() * sizeof(float));
-  std::memcpy(gamma_fp32_svm, gamma_fp32.getData<float>(),
-              gamma_fp32.size() * sizeof(float));
+  std::memcpy(in_svm, in.getData<T>(), in.size() * sizeof(T));
+  std::memcpy(gamma_svm, gamma.getData<T>(), gamma.size() * sizeof(T));
 
-  blas_cc->command_queue_inst_.enqueueSVMUnmap(in_fp32_svm);
-  blas_cc->command_queue_inst_.enqueueSVMUnmap(gamma_fp32_svm);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(in_svm);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(gamma_svm);
 
   static constexpr uint32_t run_count = 500;
   static constexpr float kEpsilon = 0.001f;
 
   Timer timer1{};
   for (unsigned int i = 0; i < run_count; ++i) {
-    rmsnorm_cl((float *)in_fp32_svm, (float *)gamma_fp32_svm,
-               (float *)out_fp32_svm, kEpsilon,
-               in_fp32.batch() * in_fp32.channel() * in_fp32.height(),
-               in_fp32.width(), true);
+    rmsnorm_cl((T *)in_svm, (T *)gamma_svm, (T *)out_svm,
+               NNTR_COMPUTE_FP32_TO_FP16(kEpsilon), in.height(), in.width(),
+               true);
   }
   auto t2_cl = timer1.GetElapsedMilliseconds();
 
@@ -1834,24 +1861,39 @@ TEST(blas_kernels, rmsnorm_fp32) {
   std::cout << "RMSNorm time : CPU = " << t2_ref / (run_count * 1.0f) << " ms"
             << std::endl;
 
-  blas_cc->command_queue_inst_.enqueueSVMMap(
-    out_fp32_svm, out_cl_fp32.size() * sizeof(float), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(out_svm, out_cl.size() * sizeof(T),
+                                             false);
 
-  float mseError = mse<float>((float *)out_fp32_svm,
-                              out_ref_fp32.getData<float>(), height * width);
+  for (int i = 0; i < out_cl.size(); ++i) {
+    out_svm_fp32[i] = NNTR_COMPUTE_FP16_TO_FP32(((T *)out_svm)[i]);
+  }
+
+  float mseError =
+    mse<float>(out_svm_fp32, out_ref_fp32.getData<float>(), height * width);
 
   double cosSim = cosine_similarity<float>(
-    (float *)out_fp32_svm, out_ref_fp32.getData<float>(), height * width);
+    out_svm_fp32, out_ref_fp32.getData<float>(), height * width);
 
-  const float epsilon = 1e-3 * width;
+  const float epsilon = 1e-3f;
 
-  freeSVM(out_fp32_svm);
-  freeSVM(in_fp32_svm);
-  freeSVM(gamma_fp32_svm);
+  freeSVM(out_svm);
+  freeSVM(in_svm);
+  freeSVM(gamma_svm);
+  delete[] out_svm_fp32;
 
   EXPECT_IN_RANGE(mseError, 0, epsilon);
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
+
+TEST(blas_kernels, rmsnorm_fp32_67_3072) {
+  rmsnorm_67_3072<float>(nntrainer::Tdatatype::FP32);
+}
+
+#ifdef ENABLE_FP16
+TEST(blas_kernels, rmsnorm_fp16_67_3072) {
+  rmsnorm_67_3072<_FP16>(nntrainer::Tdatatype::FP16);
+}
+#endif
 
 TEST(blas_kernels, swiglu_layer_fp32_67_3072) {
   const int batch = 1;


### PR DESCRIPTION
After this PR we're able to use FP16 tensors for
OpenCL computations on Windows

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>{commit-1}</summary><br />

{commit message}

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>

</details>



<details><summary>{commit-2}</summary><br />

{commit message}

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>

</details>

### Summary

- {Summary of PR 1}
- {Summary of PR 2}

Signed-off-by: {your_name} <{your_email}>
