### PR TITLE
Skip empty reviewer signal notes

### DIFF
--- a/.github/models/pr-desc/build_context.js
+++ b/.github/models/pr-desc/build_context.js
@@ -193,9 +193,18 @@ function headerOrConfig(p){
  return /\.(h|hpp|hh|hxx|inc)$/.test(p) ||
  /(^|\/)(CMakeLists\.txt|configure|.*\.cmake|.*\.bazel|build\.gradle|settings\.gradle|package\.json)$/.test(p);
 }
-const apiSurfaceChanges = changedFiles.filter(f => headerOrConfig(f.path)).map(f => f.path);
-const testFiles = changedFiles.filter(f => /(^|\/)(test|tests|testing|spec)\b|_test\.(cc|cpp|c|py|js|ts)$/.test(f.path)).map(f => f.path);
-const concurrencySensitive= changedFiles.filter(f => /(thread|mutex|atomic|lock|concurrent|parallel)/i.test(f.path)).map(f => f.path);
+const apiSurfaceChanges = changedFiles
+  .filter(f => headerOrConfig(f.path))
+  .map(f => f.path)
+  .filter(Boolean);
+const testFiles = changedFiles
+  .filter(f => /(^|\/)(test|tests|testing|spec)\b|_test\.(cc|cpp|c|py|js|ts)$/.test(f.path))
+  .map(f => f.path)
+  .filter(Boolean);
+const concurrencySensitive = changedFiles
+  .filter(f => /(thread|mutex|atomic|lock|concurrent|parallel)/i.test(f.path))
+  .map(f => f.path)
+  .filter(Boolean);
 
 // ---------- 4) Diff/Commits 텍스트 ----------
 const diff = clip(`### name-status\n${nameStatusRaw}\n\n### stat\n${statRaw}`, 8000);
@@ -234,6 +243,11 @@ if (Object.keys(moduleImpact).length) {
 }
 
 // ---------- 6) 출력 ----------
+const reviewerSignals = {};
+if (apiSurfaceChanges.length) reviewerSignals.apiSurfaceChanges = apiSurfaceChanges;
+if (testFiles.length) reviewerSignals.testFiles = testFiles;
+if (concurrencySensitive.length) reviewerSignals.concurrencySensitive = concurrencySensitive;
+
 const out = {
   overview: clip(overview, 8000),
   modules: modulesDoc,
@@ -242,11 +256,7 @@ const out = {
   // 새 필드들
   moduleImpact, // 모듈별 상세(머신 가독)
  moduleImpactSummary: moduleImpactSummary || '(no module impact detected)',
- reviewerSignals: {
- apiSurfaceChanges,
- testFiles,
- concurrencySensitive
- }
+ reviewerSignals
 };
 
 process.stdout.write(JSON.stringify(out, null, 2));

--- a/.github/models/pr-desc/build_context.js
+++ b/.github/models/pr-desc/build_context.js
@@ -193,18 +193,28 @@ function headerOrConfig(p){
  return /\.(h|hpp|hh|hxx|inc)$/.test(p) ||
  /(^|\/)(CMakeLists\.txt|configure|.*\.cmake|.*\.bazel|build\.gradle|settings\.gradle|package\.json)$/.test(p);
 }
-const apiSurfaceChanges = changedFiles
-  .filter(f => headerOrConfig(f.path))
-  .map(f => f.path)
-  .filter(Boolean);
-const testFiles = changedFiles
-  .filter(f => /(^|\/)(test|tests|testing|spec)\b|_test\.(cc|cpp|c|py|js|ts)$/.test(f.path))
-  .map(f => f.path)
-  .filter(Boolean);
-const concurrencySensitive = changedFiles
-  .filter(f => /(thread|mutex|atomic|lock|concurrent|parallel)/i.test(f.path))
-  .map(f => f.path)
-  .filter(Boolean);
+function cleanPaths(list) {
+  const sanitized = list
+    .map(p => typeof p === 'string' ? p.trim() : '')
+    .filter(p => p && /[A-Za-z0-9]/.test(p));
+  return Array.from(new Set(sanitized));
+}
+
+const apiSurfaceChanges = cleanPaths(
+  changedFiles
+    .filter(f => headerOrConfig(f.path))
+    .map(f => f.path)
+);
+const testFiles = cleanPaths(
+  changedFiles
+    .filter(f => /(^|\/)(test|tests|testing|spec)\b|_test\.(cc|cpp|c|py|js|ts)$/.test(f.path))
+    .map(f => f.path)
+);
+const concurrencySensitive = cleanPaths(
+  changedFiles
+    .filter(f => /(thread|mutex|atomic|lock|concurrent|parallel)/i.test(f.path))
+    .map(f => f.path)
+);
 
 // ---------- 4) Diff/Commits 텍스트 ----------
 const diff = clip(`### name-status\n${nameStatusRaw}\n\n### stat\n${statRaw}`, 8000);

--- a/.github/workflows/pr-desc.yml
+++ b/.github/workflows/pr-desc.yml
@@ -74,9 +74,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          : > pr_comment.md
-          # 모델 응답을 안전하게 파일에 기록 (이중 인용부호 사용)
-          printf "%s\n" "${{ steps.ai_full.outputs.response }}" >> pr_comment.md
+          # GitHub expressions are rendered before the shell executes, so use a
+          # single-quoted heredoc to prevent bash from interpreting characters
+          # like backticks as command substitutions.
+          cat <<'EOF' > pr_comment.md
+${{ steps.ai_full.outputs.response }}
+EOF
 
           echo "COMMENT_BYTES=$(wc -c < pr_comment.md)"
           head -c 200 pr_comment.md || true; echo


### PR DESCRIPTION
## Summary
- filter out empty file paths when collecting reviewer signal lists
- emit reviewer signal sections only when a corresponding file list is available

## Testing
- node .github/models/pr-desc/build_context.js --base HEAD~1 --head HEAD > /tmp/pr_ctx.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad0f4f81483339b30133681cefe8a)