### PR TITLE
Sanitize inline code in AI PR comments

### DIFF
--- a/.github/workflows/pr-desc.yml
+++ b/.github/workflows/pr-desc.yml
@@ -78,6 +78,13 @@ jobs:
           # 모델 응답을 안전하게 파일에 기록 (이중 인용부호 사용)
           printf "%s\n" "${{ steps.ai_full.outputs.response }}" >> pr_comment.md
 
+      - name: Sanitize inline code spans
+        shell: bash
+        run: |
+          set -euo pipefail
+          perl -0pe 's/`([^`]+)`/<code>\1<\/code>/g' pr_comment.md > pr_comment_sanitized.md
+          mv pr_comment_sanitized.md pr_comment.md
+
           echo "COMMENT_BYTES=$(wc -c < pr_comment.md)"
           head -c 200 pr_comment.md || true; echo
 


### PR DESCRIPTION
## Summary
- add a sanitization step after composing the AI-generated PR description comment
- replace inline backtick code spans with `<code>` elements so GitHub receives escaped HTML
- ensure the byte-count/head preview reflects the sanitized payload before posting the comment

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae9c9494c8333bec5991a7cc8a240)