### PR TITLE
Sanitize PR response earlier

### DIFF
--- a/.github/workflows/pr-desc.yml
+++ b/.github/workflows/pr-desc.yml
@@ -71,14 +71,29 @@ jobs:
             Do not add other sections.
           prompt-file: combined_prompt.txt
 
+      - name: Sanitize AI response
+        shell: bash
+        run: |
+          set -euo pipefail
+          : > pr_comment_raw.md
+          # 모델 응답을 안전하게 임시 파일에 기록 (리터럴 히어독으로 쉘 해석 방지)
+          cat <<'EOF' > pr_comment_raw.md
+${{ steps.ai_full.outputs.response }}
+EOF
+
+          # 모델 응답이 생성된 직후 모든 백틱(`)을 작은따옴표(')로 변환
+          python - <<'PY'
+from pathlib import Path
+text = Path('pr_comment_raw.md').read_text()
+Path('pr_comment.md').write_text(text.replace('`', "'"))
+PY
+          rm pr_comment_raw.md
+
       - name: Compose final comment body
         shell: bash
         run: |
           set -euo pipefail
-          : > pr_comment.md
-          # 모델 응답을 안전하게 파일에 기록 (이중 인용부호 사용)
-          printf "%s\n" "${{ steps.ai_full.outputs.response }}" >> pr_comment.md
-
+          test -f pr_comment.md
           echo "COMMENT_BYTES=$(wc -c < pr_comment.md)"
           head -c 200 pr_comment.md || true; echo
 


### PR DESCRIPTION
## Summary
- add a dedicated step immediately after the AI inference run to capture the response via a literal here-doc and replace backticks with apostrophes right away
- keep the final comment step focused on verifying/logging the sanitized file before it is posted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc6b5d6f48333a38e3bf3278bd340)